### PR TITLE
added some options

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,7 @@ Copyright 2011 Wellbury LLC - See LICENSE for license information
 Release 20110901 - Adapted from sshd_block release 20100120
 Release 20120530 - Added MSI to distribution
 Release 20190926 - forked from Evan's version; wildcard whitelist, use black-hole routing by policy
+Release 20211124 - bugfix: always Trim() whitelist from registry as trailing space screws it up
 
 For support, please contact Evan Anderson at Wellbury LLC
 EAnderson@wellbury.com, (866) 569-9799, ext 801

--- a/README.txt
+++ b/README.txt
@@ -3,6 +3,7 @@ Copyright 2011 Wellbury LLC - See LICENSE for license information
 
 Release 20110901 - Adapted from sshd_block release 20100120
 Release 20120530 - Added MSI to distribution
+Release 20190918 - forked from Evan's version; wildcard whitelist, use black-hole routing by policy
 
 For support, please contact Evan Anderson at Wellbury LLC
 EAnderson@wellbury.com, (866) 569-9799, ext 801
@@ -56,6 +57,11 @@ For Windows Vista, 2008, 7, and 2008 R2 the "Advanced Firewall" is used
 to create inbound firewall rules blocking traffic from the blocked host. 
 On these operating systems no special configuration of the registry or 
 network adapters is necessary. 
+
+NOTE: If you don't wish to use Advanced Firewall you can set the registry
+entry BlockStyle to 1 to force the use of black-hole routing. I have determined
+that (on Windows Server 2008 and above at least) using the special IP
+0.0.0.0 will work and you can ignore the below advice.
 
 Because Windows Server 2003 lacks sufficient features in its built-in 
 firewall functionality a black-hole host route is used. Unfortunately, 
@@ -119,6 +125,10 @@ Server 2003). If not specified the default algorithm of selecting the IP
 address of a network interface with no default gateway specified will be 
 used.  This setting is not used in Windows Server 2008 and later versions
 of Windows.
+
+Parameter: BlockStyle
+Type: REG_SZ
+Explanation: Forces the use of black-hole routing on Windows 2008 and above.
 
 A Group Policy Administrative Template (ADM) file is included with this 
 distribution that is capable of setting these values. Deploying a GPO 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Copyright 2011 Wellbury LLC - See LICENSE for license information
 
 Release 20110901 - Adapted from sshd_block release 20100120
 Release 20120530 - Added MSI to distribution
-Release 20190918 - forked from Evan's version; wildcard whitelist, use black-hole routing by policy
+Release 20190926 - forked from Evan's version; wildcard whitelist, use black-hole routing by policy
 
 For support, please contact Evan Anderson at Wellbury LLC
 EAnderson@wellbury.com, (866) 569-9799, ext 801
@@ -129,6 +129,12 @@ of Windows.
 Parameter: BlockStyle
 Type: REG_SZ
 Explanation: Forces the use of black-hole routing on Windows 2008 and above.
+
+Parameter: Whitelist
+Type: REG_SZ
+Explanation: A space-separated list of IPs or networks that will not be blocked.
+For example, a value of '192.168.3. 172.16.55.4' will not block any IPs that 
+start with 192.168.3. or the specific IP 172.16.55.4.
 
 A Group Policy Administrative Template (ADM) file is included with this 
 distribution that is capable of setting these values. Deploying a GPO 

--- a/ts_block.adm
+++ b/ts_block.adm
@@ -35,7 +35,21 @@ CATEGORY "Wellbury LLC"
 			PART "Black-hole IP address" EDITTEXT REQUIRED
 				VALUENAME "BlackholeIP"
 			END PART ; "Block timeout"
-			EXPLAIN "The IP address used for the black-hole route (for Windows Server 2003). If not specified the default algorithm of selecting the IP address of a network interface with no default gateway specified will be used. This setting is not used in Windows Server 2008 and later versions of Windows."
+			EXPLAIN "The IP address used for the black-hole route (for Windows Server 2003, or if specified as the BlockStyle. If not specified, the hardcoded value of 0.0.0.0 will be used (remove this to switch back to the default algorithm of selecting the IP address of a network interface with no default gateway specified will be used. This setting is not used in Windows Server 2008 and later versions of Windows UNLESS the BlockStyle is also set."
+		END POLICY
+		
+		POLICY "Block Style"
+			PART "Block Style" NUMERIC REQUIRED
+				VALUENAME "BlockStyle"
+			END PART
+			EXPLAIN "This setting allows you to manually choose to use black-hole routing on Windows Server 2008 and above, rather than the Windows Firewall (which must be enabled if you want to use it.)  Set this value to 1 to use blackhole routing, or 2 to use the Windows Firewall (or simply leave it unset to use the routing method on Windows Server 2003 and the firewall method on Windows Server 2008 and above."
+		END POLICY
+		
+		POLICY "Whitelist"
+			PART "Whitelist" EDITTEXT REQUIRED
+				VALUENAME "Whitelist"
+			END PART 
+			EXPLAIN "This setting allows you to specify a space-separated list of IPs or network prefixes which will never be blocked.  For instance, the value '1.2.3.4 192.168.3. 10.' will never block requests from IP 1.2.3.4, or and IPs where the first digits match 192.168.3., or any IPs that start with 10."
 		END POLICY
 
 	END CATEGORY ; "ts_block"

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -72,7 +72,7 @@ dictBlockImmediatelyUsers.Add "guest", 1
 
 ' ===================( End Configuration )===================
 
-Const TS_BLOCK_VERSION = "20110831"
+Const TS_BLOCK_VERSION = "20190918"
 Const BLACKHOLE_ROUTE = 1		' Blackhole packets via routing table
 Const BLACKHOLE_FIREWALL = 2	' Blackhole packets via firewall
 

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -220,14 +220,26 @@ Sub Block(IP)
 	Dim intRemoveBlockTime
 
 	' don't block special IPs
-	If InStr("0.0.0.0",IP) > 0 Then Exit Sub
-	If InStr("255.255.255.255",IP) > 0 Then Exit Sub
-	If InStr("127.0.0.1",IP) > 0 Then Exit Sub
+	If InStr("0.0.0.0",IP) > 0 Then 
+		LogEvent 258, EVENTLOG_TYPE_INFORMATION, "Skipped " & IP & " because it is a special system IP."
+		Exit Sub
+	End If
+	If InStr("255.255.255.255",IP) > 0 Then 
+		LogEvent 258, EVENTLOG_TYPE_INFORMATION, "Skipped " & IP & " because it is a special system IP."
+		Exit Sub
+	End If
+	If InStr("127.0.0.1",IP) > 0 Then
+		LogEvent 258, EVENTLOG_TYPE_INFORMATION, "Skipped " & IP & " because it is a special system IP."
+		Exit Sub
+	End If
 
 	' split whitelist by spaces and check if each one is part of IP for wildcard matches
 	Wi = Split(strWhitelist)
 	For Each Wx in Wi
-		If InStr(IP,Wx) > 0 Then Exit Sub
+		If InStr(IP,Wx) > 0 Then 
+			LogEvent 258, EVENTLOG_TYPE_INFORMATION, "Skipped " & IP & " because it is whitelisted."
+			Exit Sub
+		End If
 	Next
 
 	' get list of local IP addresses and don't block those either - can cause problems!
@@ -245,7 +257,10 @@ Sub Block(IP)
                 End If
             End If
 	Next
-	If InStr(strLocalIP,IP) > 0 Then Exit Sub
+	If InStr(strLocalIP,IP) > 0 Then 
+		LogEvent 258, EVENTLOG_TYPE_INFORMATION, "Skipped " & IP & " because it is configured on a network interface."
+		Exit Sub
+	End If
 
 	' Block an IP address (either by black-hole routing it or adding a firewall rule)
 	If (TESTING <> 1) Then 	

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -53,7 +53,10 @@ Const DEFAULT_BLOCK_TIMEOUT = 120	' in X seconds
 Const REG_BLOCK_TIMEOUT = "BlockTimeout"
 
 ' Black hole IP address (if hard-specified)
-Const REG_BLACKHOLE_IP = "0.0.0.0"
+Const REG_BLACKHOLE_IP = "BlackholeIP"
+
+' Blocking style (may prefer to use routing if Windows Firewall is disabled)
+Const REG_BLOCK_STYLE = "BlockStyle"
 
 ' Usernames that attempted logons for result in immediate blocking
 Set dictBlockImmediatelyUsers = CreateObject("Scripting.Dictionary")
@@ -112,7 +115,6 @@ For Each intOSBuild in colOperatingSystem
 		WScript.Quit EVENTLOG_ID_ERROR_WIN_XP
 	End If
 	
-	If DEBUGGING Then WScript.Echo "intBlackHoleStyle = " & intBlackHoleStyle 
 Next ' intOSBuild
 
 ' Read configuration from the registry, if present, in a really simplsitic way
@@ -129,8 +131,12 @@ If CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_TIMEOUT)) > 0 Then intBlock
 If objShell.RegRead(REG_CONFIG_PATH & REG_BLACKHOLE_IP) <> "" Then
 	blackHoleIPAddress = regexpSanitizeIP.Replace(objShell.RegRead(REG_CONFIG_PATH & REG_BLACKHOLE_IP), "")
 Else
-	blackHoleIPAddress = ""
+	blackHoleIPAddress = "0.0.0.0"
 End If
+
+' Override block style if set in registry
+If CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_STYLE)) > 0 Then intBlockStyle = CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_STYLE))
+If DEBUGGING Then WScript.Echo "intBlackHoleStyle = " & intBlackHoleStyle 
 
 On Error Goto 0
 

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -53,7 +53,7 @@ Const DEFAULT_BLOCK_TIMEOUT = 120	' in X seconds
 Const REG_BLOCK_TIMEOUT = "BlockTimeout"
 
 ' Black hole IP address (if hard-specified)
-Const REG_BLACKHOLE_IP = "BlackholeIP"
+Const REG_BLACKHOLE_IP = "0.0.0.0"
 
 ' Usernames that attempted logons for result in immediate blocking
 Set dictBlockImmediatelyUsers = CreateObject("Scripting.Dictionary")

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -161,7 +161,8 @@ If DEBUGGING Then LogEvent EVENTLOG_ID_STARTED, EVENTLOG_TYPE_INFORMATION, "Bloc
 If DEBUGGING Then LogEvent EVENTLOG_ID_STARTED, EVENTLOG_TYPE_INFORMATION, "Block Attempts: " & intBlockAttempts
 If DEBUGGING Then LogEvent EVENTLOG_ID_STARTED, EVENTLOG_TYPE_INFORMATION, "Block Timeout: " & intBlockTimeout
 If DEBUGGING Then LogEvent EVENTLOG_ID_STARTED, EVENTLOG_TYPE_INFORMATION, "Blackhole IP: " &  blackHoleIPAddress
-
+If DEBUGGING Then LogEvent EVENTLOG_ID_STARTED, EVENTLOG_TYPE_INFORMATION, "Whitelist: " & strWhitelist
+																		
 ' Create event sink to catch security events
 Set objEventSink = WScript.CreateObject("WbemScripting.SWbemSink", "eventSink_")
 objWMIService.ExecNotificationQueryAsync objEventSink, "SELECT * FROM __InstanceCreationEvent WHERE TargetInstance ISA 'Win32_NTLogEvent' AND TargetInstance.Logfile = 'Security' AND TargetInstance.EventType = 5 AND (TargetInstance.EventIdentifier = 529 OR TargetInstance.EventIdentifier = 4625) AND (TargetInstance.SourceName = 'Security' OR TargetInstance.SourceName = 'Microsoft-Windows-Security-Auditing')"

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -217,8 +217,13 @@ Sub Block(IP)
 	Dim strRunCommand
 	Dim intRemoveBlockTime
 
+	' don't block special IPs
+	If InStr("0.0.0.0",IP) > 0 Then Exit Sub
+	If InStr("255.255.255.255",IP) > 0 Then Exit Sub
+
 	' don't block if IP is in whitelist (no need to log)
 	If InStr(strWhitelist,IP) > 0 Then Exit Sub
+
 	' Block an IP address (either by black-hole routing it or adding a firewall rule)
 	If (TESTING <> 1) Then 	
 		If intBlackholeStyle = BLACKHOLE_ROUTE Then strRunCommand = "route add " & IP & " mask 255.255.255.255 " & blackHoleIPAddress 

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -229,7 +229,7 @@ Sub Unblock(IP)
 	Dim strRunCommand
 
 	If (TESTING <> 1) Then 
-		If intBlackholeStyle = BLACKHOLE_ROUTE Then strRunCommand = "route delete " & IP & " mask 255.255.255.255 " & blackHoleIPAddress  
+		If intBlackholeStyle = BLACKHOLE_ROUTE Then strRunCommand = "route delete " & IP
 		If intBlackholeStyle = BLACKHOLE_FIREWALL Then strRunCommand = "netsh advfirewall firewall delete rule name=""Blackhole " & IP & """"
 
 		If DEBUGGING Then WScript.Echo "Executing " & strRunCommand

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -5,7 +5,7 @@ Option Explicit
 '
 ' Release 20110831 - Adapted from sshd_block release 20100120
 ' Release 20120530 - No change from 20110831 code for ts_block script
-' Release 20190918 - forked from Evan's version; wildcard whitelist, use black-hole routing by policy
+' Release 20190926 - forked from Evan's version; wildcard whitelist, use black-hole routing by policy
 
 ' External executables required to be accessible from PATH:
 '
@@ -72,7 +72,7 @@ dictBlockImmediatelyUsers.Add "guest", 1
 
 ' ===================( End Configuration )===================
 
-Const TS_BLOCK_VERSION = "20190918"
+Const TS_BLOCK_VERSION = "20190926"
 Const BLACKHOLE_ROUTE = 1		' Blackhole packets via routing table
 Const BLACKHOLE_FIREWALL = 2	' Blackhole packets via firewall
 

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -218,6 +218,8 @@ Sub Block(IP)
 	' Block an IP address and set the time for the block expiration
 	Dim strRunCommand
 	Dim intRemoveBlockTime
+	Dim Wi,Wx
+	Dim strQuery,objWMIService,colItems,objItem,strLocalIP
 
 	' don't block special IPs
 	If InStr("0.0.0.0",IP) > 0 Then 

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -220,6 +220,7 @@ Sub Block(IP)
 	' don't block special IPs
 	If InStr("0.0.0.0",IP) > 0 Then Exit Sub
 	If InStr("255.255.255.255",IP) > 0 Then Exit Sub
+	If InStr("127.0.0.1",IP) > 0 Then Exit Sub
 
 	' don't block if IP is in whitelist (no need to log)
 	If InStr(strWhitelist,IP) > 0 Then Exit Sub

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -53,6 +53,7 @@ Const DEFAULT_BLOCK_TIMEOUT = 120	' in X seconds
 Const REG_BLOCK_TIMEOUT = "BlockTimeout"
 
 ' Black hole IP address (if hard-specified)
+Const DEFAULT_BLACKHOLE_IP = "0.0.0.0"
 Const REG_BLACKHOLE_IP = "BlackholeIP"
 
 ' Blocking style (may prefer to use routing if Windows Firewall is disabled)
@@ -128,14 +129,13 @@ If CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_ATTEMPTS)) > 0 Then intBloc
 intBlockTimeout = DEFAULT_BLOCK_TIMEOUT
 If CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_TIMEOUT)) > 0 Then intBlockTimeout = CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_TIMEOUT))
 
+blackHoleIPAddress = DEFAULT_BLACKHOLE_IP
 If objShell.RegRead(REG_CONFIG_PATH & REG_BLACKHOLE_IP) <> "" Then
 	blackHoleIPAddress = regexpSanitizeIP.Replace(objShell.RegRead(REG_CONFIG_PATH & REG_BLACKHOLE_IP), "")
-Else
-	blackHoleIPAddress = "0.0.0.0"
 End If
 
 ' Override block style if set in registry
-If CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_STYLE)) > 0 Then intBlockStyle = CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_STYLE))
+If CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_STYLE)) > 0 Then intBlackHoleStyle = CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_STYLE))
 If DEBUGGING Then WScript.Echo "intBlackHoleStyle = " & intBlackHoleStyle 
 
 On Error Goto 0

--- a/ts_block.vbs
+++ b/ts_block.vbs
@@ -6,6 +6,7 @@ Option Explicit
 ' Release 20110831 - Adapted from sshd_block release 20100120
 ' Release 20120530 - No change from 20110831 code for ts_block script
 ' Release 20190926 - forked from Evan's version; wildcard whitelist, use black-hole routing by policy
+' Release 20211124 - bugfix: always Trim() whitelist from registry as trailing space screws it up
 
 ' External executables required to be accessible from PATH:
 '
@@ -135,7 +136,7 @@ intBlockTimeout = DEFAULT_BLOCK_TIMEOUT
 If CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_TIMEOUT)) > 0 Then intBlockTimeout = CInt(objShell.RegRead(REG_CONFIG_PATH & REG_BLOCK_TIMEOUT))
 
 strWhitelist = ""
-If objShell.RegRead(REG_CONFIG_PATH & REG_WHITELIST) <> "" Then strWhitelist = objShell.RegRead(REG_CONFIG_PATH & REG_WHITELIST)
+If objShell.RegRead(REG_CONFIG_PATH & REG_WHITELIST) <> "" Then strWhitelist = Trim(objShell.RegRead(REG_CONFIG_PATH & REG_WHITELIST))
 
 blackHoleIPAddress = DEFAULT_BLACKHOLE_IP
 If objShell.RegRead(REG_CONFIG_PATH & REG_BLACKHOLE_IP) <> "" Then


### PR DESCRIPTION
hi - i made a couple changes which work for me 
1 - because i'm disabling advanced f/w i wanted to use route method on newer versions of windows, so i created registry entries to set this as a preference (didn't modify the ADM)
2 - i found that using an IP of 0.0.0.0 as my blackhole IP worked (seems insane of course, but try it yourself and you'll see!) so I made that the default in case it's not defined by the other methods
3 - i changed the route delete command to only refer to the blacklisted IP since this works and the full command doesn't work if I use 0.0.0.0 as my blackhole IP 